### PR TITLE
Sync only restricted groups

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/.project
+++ b/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>sonar-auth-aad-plugin</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/main/resources=UTF-8
+encoding//src/test/java=UTF-8
+encoding/<project>=UTF-8

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.source=1.8

--- a/.settings/org.eclipse.m2e.core.prefs
+++ b/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,31 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "compile",
+            "type": "shell",
+            "command": "mvn -B compile",
+            "group": "build"
+        },
+        {
+            "label": "verify",
+            "type": "shell",
+            "command": "mvn -B verify",
+            "group": "build"
+        },
+        {
+            "label": "test",
+            "type": "shell",
+            "command": "mvn -B test",
+            "group": "test"
+        },
+        {
+            "label": "package",
+            "type": "shell",
+            "command": "mvn -B package",
+            "group": "build"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ Installation and configurations
 | Property Key                    | Property Name                 | Description                                                                                                                                                                             | Default value |
 |---------------------------------|-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
 | sonar.auth.aad.enableGroupsSync | Enable Groups Synchronization | Enable groups syncronization from Azure AD to SonarQube, For each Azure AD group user belongs to, the user will be associated to a group with the same name(if it exists) in SonarQube. | false         |
-
 | sonar.auth.aad.restrictedGroups | Restricted Groups | Synchronize only restricted user groups of which the user has a <b>direct or transitive membership</b>. If this value is populated only groups mentioned will get sync and the user will be associated to a group with the same name(if it exists) in SonarQube.\\n ex: {\"GroupDisplayNameinAzureAD\":\"GroupObjectIdInAzureAD\",\"Group2DisplayNameinAzureAD\":\"Group2ObjectIdInAzureAD\"}  | 
 
 Additional Configurations

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Proxy](http://docs.sonarqube.org/display/SONAR/Securing+the+Server+Behind+a+Prox
 
 	![Singin permission](./_img/permissions.png)
 
-1. If you enabled group synchronization, make sure the application has access to **Windows Azure Active Directory**. **Read all groups** delegated permissions should be selected.
+1. If you enabled group synchronization, make sure the application has access to **Windows Azure Active Directory**. **Read all groups & Read directory data** delegated permissions should be selected.
 
 	![groups permission](./_img/groups_sync.png)
 
@@ -133,6 +133,8 @@ Installation and configurations
 | Property Key                    | Property Name                 | Description                                                                                                                                                                             | Default value |
 |---------------------------------|-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
 | sonar.auth.aad.enableGroupsSync | Enable Groups Synchronization | Enable groups syncronization from Azure AD to SonarQube, For each Azure AD group user belongs to, the user will be associated to a group with the same name(if it exists) in SonarQube. | false         |
+
+| sonar.auth.aad.restrictedGroups | Restricted Groups | Synchronize only restricted user groups of which the user has a <b>direct or transitive membership</b>. If this value is populated only groups mentioned will get sync and the user will be associated to a group with the same name(if it exists) in SonarQube.\\n ex: {\"GroupDisplayNameinAzureAD\":\"GroupObjectIdInAzureAD\",\"Group2DisplayNameinAzureAD\":\"Group2ObjectIdInAzureAD\"}  | 
 
 Additional Configurations
 -------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>adal4j</artifactId>
-            <version>1.3.0</version>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/src/main/java/org/almrangers/auth/aad/HttpClientHelper.java
+++ b/src/main/java/org/almrangers/auth/aad/HttpClientHelper.java
@@ -23,6 +23,7 @@ package org.almrangers.auth.aad;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -46,6 +47,38 @@ public class HttpClientHelper {
     while ((line = reader.readLine()) != null) {
       stringBuffer.append(line);
     }
+
+    return stringBuffer.toString();
+  }
+
+  public static String getResponseStringFromConn(HttpURLConnection conn, String payLoad) throws IOException {
+    BufferedReader br = null;
+    // Send the http message payload to the server.
+    if (payLoad != null) {
+      conn.setDoOutput(true);
+      OutputStreamWriter osw = new OutputStreamWriter(conn.getOutputStream());
+      osw.write(payLoad);
+      osw.flush();
+      osw.close();
+    }
+
+    int responseCode = conn.getResponseCode();
+    if (responseCode == HttpURLConnection.HTTP_OK) {
+      // Get the message response from the server.
+      br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+     
+    }
+    else {
+       br = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
+    }
+
+    String line = "";
+    StringBuffer stringBuffer = new StringBuffer();
+    while ((line = br.readLine()) != null) {
+      stringBuffer.append(line);
+    }
+
+    br.close();
 
     return stringBuffer.toString();
   }

--- a/src/main/java/org/almrangers/auth/aad/JSONHelper.java
+++ b/src/main/java/org/almrangers/auth/aad/JSONHelper.java
@@ -23,6 +23,11 @@ import java.lang.reflect.Field;
 import org.apache.commons.lang3.text.WordUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.json.JSONException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 public class JSONHelper {
 
@@ -70,5 +75,28 @@ public class JSONHelper {
           .invoke(destObject, jsonObject.optString(fieldList[i].getName()));
       }
     }
+  }
+
+  public static Map<String, String> jsonToMap(String t)  {
+
+    HashMap<String, String> map = new HashMap<String, String>();
+    try
+    {
+      if(t != null && !t.isEmpty()) {
+        JSONObject jObject = new JSONObject(t);
+        Iterator<?> keys = jObject.keys();
+  
+        while( keys.hasNext() ){
+            String key = (String)keys.next();
+            String value = jObject.getString(key); 
+            map.put(key, value);
+        }
+      }
+
+    } catch (JSONException e) {
+      e.printStackTrace();
+    }
+
+    return map;
   }
 }

--- a/src/test/java/org/almrangers/auth/aad/AadSettingsTest.java
+++ b/src/test/java/org/almrangers/auth/aad/AadSettingsTest.java
@@ -112,8 +112,23 @@ public class AadSettingsTest {
   }
 
   @Test
+  public void enable_Group_Sync() {
+    settings.setProperty("sonar.auth.aad.enableGroupsSync", "true");
+    assertThat(underTest.enableGroupSync()).isTrue();
+
+    settings.setProperty("sonar.auth.aad.enableGroupsSync", "false");
+    assertThat(underTest.enableGroupSync()).isFalse();
+  }
+
+  @Test
+  public void restricted_GroupsString() {
+    settings.setProperty("sonar.auth.aad.restrictedGroups", "restrictedGroups");
+    assertThat(underTest.restrictedGroupsString()).isEqualTo("restrictedGroups");
+  }
+
+  @Test
   public void definitions() {
-    assertThat(AadSettings.definitions()).hasSize(8);
+    assertThat(AadSettings.definitions()).hasSize(9);
   }
 
 }

--- a/src/test/java/org/almrangers/auth/aad/AuthAadPluginTest.java
+++ b/src/test/java/org/almrangers/auth/aad/AuthAadPluginTest.java
@@ -35,7 +35,7 @@ public class AuthAadPluginTest {
 
   @Test
   public void test_extensions() {
-    assertThat(underTest.getExtensions()).hasSize(10);
+    assertThat(underTest.getExtensions()).hasSize(11);
   }
 
 }


### PR DESCRIPTION
Below are the two items i have worked on and raised pull request. 

1. Group Synchronization details are not visible in Current UI. Fixed the bug.
2. In the current group synchronization, groups where user has transitive membership are ignored. Added functionality to synchronize only restricted user groups of which the user has a direct or transitive membership.

Note: I am a new to java environment. Please let me know if there any code improvements should be made. Please let me know is there any bug or feature id already exits for these items so that i can map them to this pull request. 

![groupsync](https://user-images.githubusercontent.com/13975252/34371172-c84563b0-eaf0-11e7-98a9-c9333fcb76b1.png)
