### PR TITLE
Fix user name handling for AAD tenant guest users

### DIFF
--- a/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
+++ b/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
@@ -62,8 +62,6 @@ import static org.almrangers.auth.aad.AadSettings.LOGIN_STRATEGY_UNIQUE;
 @ServerSide
 public class AadIdentityProvider implements OAuth2IdentityProvider {
 
-  public static final String NAME_FALLBACK = "Anonymous Azure AD User";
-
   private static final String KEY = "aad";
   private static final String NAME = "Microsoft";
   private static final String NAME_CLAIM = "name";
@@ -164,7 +162,7 @@ public class AadIdentityProvider implements OAuth2IdentityProvider {
       }
     }
     LOGGER.warn(String.format("User's name not found from authentication token for user %s", userInfo.getUniqueId()));
-    return NAME_FALLBACK;
+    return userInfo.getDisplayableId();
   }
 
   private String getLogin(UserInfo aadUser) {

--- a/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
+++ b/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
@@ -35,6 +35,7 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.util.Base64;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -60,8 +61,13 @@ import static org.almrangers.auth.aad.AadSettings.LOGIN_STRATEGY_UNIQUE;
 
 @ServerSide
 public class AadIdentityProvider implements OAuth2IdentityProvider {
+
+  public static final String NAME_FALLBACK = "Anonymous Azure AD User";
+
   private static final String KEY = "aad";
   private static final String NAME = "Microsoft";
+  private static final String NAME_CLAIM = "name";
+  private static final int JWT_PAYLOAD_PART_INDEX = 1;
   private static final Logger LOGGER = Loggers.get(AadIdentityProvider.class);
 
   private final AadSettings settings;
@@ -127,7 +133,7 @@ public class AadIdentityProvider implements OAuth2IdentityProvider {
       UserIdentity.Builder userIdentityBuilder = UserIdentity.builder()
         .setProviderLogin(aadUser.getDisplayableId())
         .setLogin(getLogin(aadUser))
-        .setName(aadUser.getGivenName() + " " + aadUser.getFamilyName())
+        .setName(getUserName(result))
         .setEmail(aadUser.getDisplayableId());
       if (settings.enableGroupSync()) {
         userGroups = getUserGroupsMembership(result.getAccessToken(), result.getUserInfo().getUniqueId());
@@ -142,6 +148,23 @@ public class AadIdentityProvider implements OAuth2IdentityProvider {
         service.shutdown();
       }
     }
+  }
+
+  String getUserName(AuthenticationResult result) {
+    UserInfo userInfo = result.getUserInfo();
+    if (userInfo.getGivenName() != null && userInfo.getFamilyName() != null) {
+      return userInfo.getGivenName() + " " + userInfo.getFamilyName();
+    }
+
+    if (result.getIdToken() != null) {
+      String base64EncodedJWTPayload = result.getIdToken().split("\\.")[JWT_PAYLOAD_PART_INDEX];
+      JSONObject token = new JSONObject(new String(Base64.getDecoder().decode(base64EncodedJWTPayload)));
+      if (token.has(NAME_CLAIM)) {
+        return token.getString(NAME_CLAIM);
+      }
+    }
+    LOGGER.warn(String.format("User's name not found from authentication token for user %s", userInfo.getUniqueId()));
+    return NAME_FALLBACK;
   }
 
   private String getLogin(UserInfo aadUser) {

--- a/src/test/java/org/almrangers/auth/aad/AadIdentityProviderTest.java
+++ b/src/test/java/org/almrangers/auth/aad/AadIdentityProviderTest.java
@@ -52,6 +52,7 @@ public class AadIdentityProviderTest {
 
   private static final String GIVEN_NAME = "GivenName";
   private static final String FAMILY_NAME = "FamilyName";
+  private static final String DISPLAYABLE_ID = "DisplayableId";
   private static final String EXPECTED_NAME = GIVEN_NAME + " " + FAMILY_NAME;
   private static final String JSON_WITH_NAME = "{\"name\": \"" + EXPECTED_NAME + "\"}";
   private static final String EMPTY_JSON = "{}";
@@ -159,11 +160,12 @@ public class AadIdentityProviderTest {
     UserInfo mockUserInfo = mock(UserInfo.class);
     doReturn(null).when(mockUserInfo).getGivenName();
     doReturn(null).when(mockUserInfo).getFamilyName();
+    doReturn(DISPLAYABLE_ID).when(mockUserInfo).getDisplayableId();
     AuthenticationResult mockResult = mock(AuthenticationResult.class);
     doReturn(mockUserInfo).when(mockResult).getUserInfo();
     doReturn(getMockJWT(EMPTY_JSON, EMPTY_JSON, EMPTY_JSON)).when(mockResult).getIdToken();
 
-    assertEquals(AadIdentityProvider.NAME_FALLBACK, underTest.getUserName(mockResult));
+    assertEquals(DISPLAYABLE_ID, underTest.getUserName(mockResult));
   }
 
   @Test
@@ -171,11 +173,12 @@ public class AadIdentityProviderTest {
     UserInfo mockUserInfo = mock(UserInfo.class);
     doReturn(null).when(mockUserInfo).getGivenName();
     doReturn(null).when(mockUserInfo).getFamilyName();
+    doReturn(DISPLAYABLE_ID).when(mockUserInfo).getDisplayableId();
     AuthenticationResult mockResult = mock(AuthenticationResult.class);
     doReturn(mockUserInfo).when(mockResult).getUserInfo();
     doReturn(null).when(mockResult).getIdToken();
 
-    assertEquals(AadIdentityProvider.NAME_FALLBACK, underTest.getUserName(mockResult));
+    assertEquals(DISPLAYABLE_ID, underTest.getUserName(mockResult));
   }
 
   private String getMockJWT(String header, String payload, String signature) {

--- a/src/test/java/org/almrangers/auth/aad/AadIdentityProviderTest.java
+++ b/src/test/java/org/almrangers/auth/aad/AadIdentityProviderTest.java
@@ -37,8 +37,10 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.HashSet;
+import java.util.Base64;
 
+import com.microsoft.aad.adal4j.AuthenticationResult;
+import com.microsoft.aad.adal4j.UserInfo;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -47,6 +49,12 @@ import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.server.authentication.OAuth2IdentityProvider;
 
 public class AadIdentityProviderTest {
+
+  private static final String GIVEN_NAME = "GivenName";
+  private static final String FAMILY_NAME = "FamilyName";
+  private static final String EXPECTED_NAME = GIVEN_NAME + " " + FAMILY_NAME;
+  private static final String JSON_WITH_NAME = "{\"name\": \"" + EXPECTED_NAME + "\"}";
+  private static final String EMPTY_JSON = "{}";
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
@@ -121,6 +129,61 @@ public class AadIdentityProviderTest {
 
     settings.setProperty("sonar.auth.aad.enabled", false);
     assertThat(underTest.isEnabled()).isFalse();
+  }
+
+  @Test
+  public void shouldParseUsersNameFromUserInfoIfNotNull() {
+    UserInfo mockUserInfo = mock(UserInfo.class);
+    doReturn(GIVEN_NAME).when(mockUserInfo).getGivenName();
+    doReturn(FAMILY_NAME).when(mockUserInfo).getFamilyName();
+    AuthenticationResult mockResult = mock(AuthenticationResult.class);
+    doReturn(mockUserInfo).when(mockResult).getUserInfo();
+
+    assertEquals(GIVEN_NAME + " " + FAMILY_NAME, underTest.getUserName(mockResult));
+  }
+
+  @Test
+  public void shouldParseUsersNameFromIdTokenIfUserInfoNameNull() {
+    UserInfo mockUserInfo = mock(UserInfo.class);
+    doReturn(null).when(mockUserInfo).getGivenName();
+    doReturn(null).when(mockUserInfo).getFamilyName();
+    AuthenticationResult mockResult = mock(AuthenticationResult.class);
+    doReturn(mockUserInfo).when(mockResult).getUserInfo();
+    doReturn(getMockJWT(EMPTY_JSON, JSON_WITH_NAME, EMPTY_JSON)).when(mockResult).getIdToken();
+
+    assertEquals(EXPECTED_NAME, underTest.getUserName(mockResult));
+  }
+
+  @Test
+  public void shouldFallBackToAnonymousIfNoNameFoundForUser() {
+    UserInfo mockUserInfo = mock(UserInfo.class);
+    doReturn(null).when(mockUserInfo).getGivenName();
+    doReturn(null).when(mockUserInfo).getFamilyName();
+    AuthenticationResult mockResult = mock(AuthenticationResult.class);
+    doReturn(mockUserInfo).when(mockResult).getUserInfo();
+    doReturn(getMockJWT(EMPTY_JSON, EMPTY_JSON, EMPTY_JSON)).when(mockResult).getIdToken();
+
+    assertEquals(AadIdentityProvider.NAME_FALLBACK, underTest.getUserName(mockResult));
+  }
+
+  @Test
+  public void shouldHandleNullIdToken() {
+    UserInfo mockUserInfo = mock(UserInfo.class);
+    doReturn(null).when(mockUserInfo).getGivenName();
+    doReturn(null).when(mockUserInfo).getFamilyName();
+    AuthenticationResult mockResult = mock(AuthenticationResult.class);
+    doReturn(mockUserInfo).when(mockResult).getUserInfo();
+    doReturn(null).when(mockResult).getIdToken();
+
+    assertEquals(AadIdentityProvider.NAME_FALLBACK, underTest.getUserName(mockResult));
+  }
+
+  private String getMockJWT(String header, String payload, String signature) {
+    return Base64.getEncoder().encodeToString(header.getBytes())
+      + "."
+      + Base64.getEncoder().encodeToString(payload.getBytes())
+      + "."
+      + Base64.getEncoder().encodeToString(signature.getBytes());
   }
 
   private void setSettings(boolean enabled) {


### PR DESCRIPTION
Fixes issue #35. 

Reads user's name from `name` claim if not available in `given_name` and `family_name` in JWT token.