### PR TITLE
Add azure pipelines CI build pipeline definition

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,44 @@
+trigger:
+- master
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  - name: sonarOrganization
+    value: 'srvrguy-github'
+  - name: sonarServiceConnectionName
+    value: 'sonarcloud'
+
+steps:
+- task: SonarCloudPrepare@1
+  inputs:
+    SonarCloud: '$(sonarServiceConnectionName)'
+    organization: '$(sonarOrganization)'
+    scannerMode: 'Other'
+
+- task: Maven@3
+  displayName: 'Maven build'
+  inputs:
+    mavenPomFile: 'pom.xml'
+    jdkVersionOption: '1.8'
+    publishJUnitResults: true
+    testResultsFiles: '**/surefire-reports/TEST-*.xml'
+    goals: 'clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar'
+    options: '--batch-mode'
+    sonarQubeRunAnalysis: true
+
+- task: CopyFiles@2
+  displayName: 'Copy Files to: $(build.artifactstagingdirectory)'
+  inputs:
+    SourceFolder: '$(system.defaultworkingdirectory)'
+    Contents: '**/target/*.jar'
+    TargetFolder: '$(build.artifactstagingdirectory)'
+  condition: succeededOrFailed()
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact: drop'
+  inputs:
+    PathtoPublish: '$(build.artifactstagingdirectory)'
+  condition: succeededOrFailed()
+


### PR DESCRIPTION
Added

Change the two variables to define a different sonarcloud organization or the service connection name

Only triggered on master.

Steps to enable it
* Create an azure devops public team project on an existing organization or a new one
* Create a service connection on the team project with your sonarcloud token
  * Name it _sonarcloud_ or name it any other name you like and then place the new name in the **sonarServiceConnectionName** variable  
* Install and configure [Pipelines app](https://github.com/marketplace/azure-pipelines)
  * configure the pipeline on azure devops (the wizard will do that for you or do it manually)

The pipeline copies the result jar to pipeline artifacts, you can delete the two last steps if this is not required.

Potential enhancements:

* Publish a release to GitHub using the built in [task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/github-release?view=azure-devops)
