### PR TITLE
API and Deprecation Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,10 +109,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-		    <groupId>org.apache.commons</groupId>
-		    <artifactId>commons-lang3</artifactId>
-		    <version>3.7</version>
-		</dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.7</version>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
+++ b/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
@@ -182,7 +182,7 @@ public class AadIdentityProvider implements OAuth2IdentityProvider {
   }
 
   URL getUrl(String userId, String nextPage) throws MalformedURLException {
-	  String url =  String.format(settings.getGraphMembershipUrl(), settings.tenantId(), userId);
+	  String url =  String.format(settings.getGraphMembershipUrl(), settings.tenantId().orElse("common"), userId);
 	if (null != nextPage) {
 		url = nextPage;
 	}

--- a/src/main/java/org/almrangers/auth/aad/AuthAadPlugin.java
+++ b/src/main/java/org/almrangers/auth/aad/AuthAadPlugin.java
@@ -29,17 +29,20 @@ package org.almrangers.auth.aad;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.sonar.api.SonarPlugin;
+import org.sonar.api.Plugin;
 
-public class AuthAadPlugin extends SonarPlugin {
+public class AuthAadPlugin implements Plugin {
 
   @Override
-  public List getExtensions() {
-    List extensions = new ArrayList();
+  public void define(Context context) {
+    List<Object> extensions = new ArrayList<>();
+
     extensions.add(AadIdentityProvider.class);
     extensions.add(AadSettings.class);
+
     extensions.addAll(AadSettings.definitions());
-    return extensions;
+
+    context.addExtensions(extensions);
   }
 
 }

--- a/src/main/java/org/almrangers/auth/aad/JSONHelper.java
+++ b/src/main/java/org/almrangers/auth/aad/JSONHelper.java
@@ -21,7 +21,7 @@ package org.almrangers.auth.aad;
 
 import java.lang.reflect.Field;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.text.WordUtils;
+import org.apache.commons.text.WordUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 

--- a/src/test/java/org/almrangers/auth/aad/AadIdentityProviderTest.java
+++ b/src/test/java/org/almrangers/auth/aad/AadIdentityProviderTest.java
@@ -44,7 +44,6 @@ import com.microsoft.aad.adal4j.UserInfo;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.sonar.api.config.Settings;
 import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.server.authentication.OAuth2IdentityProvider;
 
@@ -59,8 +58,8 @@ public class AadIdentityProviderTest {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
-  Settings settings = new MapSettings();
-  AadSettings aadSettings = new AadSettings(settings);
+  MapSettings settings = new MapSettings();
+  AadSettings aadSettings = new AadSettings(settings.asConfig());
   AadIdentityProvider underTest = spy(new AadIdentityProvider(aadSettings));
 
   @Test

--- a/src/test/java/org/almrangers/auth/aad/AadSettingsTest.java
+++ b/src/test/java/org/almrangers/auth/aad/AadSettingsTest.java
@@ -28,16 +28,15 @@ package org.almrangers.auth.aad;
 
 import org.junit.Test;
 import org.sonar.api.config.PropertyDefinitions;
-import org.sonar.api.config.Settings;
 import org.sonar.api.config.internal.MapSettings;
 
 import static org.almrangers.auth.aad.AadSettings.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AadSettingsTest {
-  Settings settings = new MapSettings(new PropertyDefinitions(AadSettings.definitions()));
+  MapSettings settings = new MapSettings(new PropertyDefinitions(AadSettings.definitions()));
 
-  AadSettings underTest = new AadSettings(settings);
+  AadSettings underTest = new AadSettings(settings.asConfig());
 
   @Test
   public void is_enabled() {
@@ -116,19 +115,19 @@ public class AadSettingsTest {
 
   @Test
   public void default_login_strategy_is_unique_login() {
-    assertThat(underTest.loginStrategy()).isEqualTo(AadSettings.LOGIN_STRATEGY_UNIQUE);
+    assertThat(underTest.loginStrategy().orElse(null)).isEqualTo(AadSettings.LOGIN_STRATEGY_UNIQUE);
   }
 
   @Test
   public void return_client_id() {
     settings.setProperty("sonar.auth.aad.clientId.secured", "id");
-    assertThat(underTest.clientId()).isEqualTo("id");
+    assertThat(underTest.clientId().orElse(null)).isEqualTo("id");
   }
 
   @Test
   public void return_client_secret() {
     settings.setProperty("sonar.auth.aad.clientSecret.secured", "secret");
-    assertThat(underTest.clientSecret()).isEqualTo("secret");
+    assertThat(underTest.clientSecret().orElse(null)).isEqualTo("secret");
   }
 
   @Test
@@ -144,5 +143,4 @@ public class AadSettingsTest {
   public void definitions() {
     assertThat(AadSettings.definitions()).hasSize(9);
   }
-
 }

--- a/src/test/java/org/almrangers/auth/aad/AuthAadPluginTest.java
+++ b/src/test/java/org/almrangers/auth/aad/AuthAadPluginTest.java
@@ -27,15 +27,26 @@
 package org.almrangers.auth.aad;
 
 import org.junit.Test;
+import org.sonar.api.Plugin;
+import org.sonar.api.SonarQubeSide;
+import org.sonar.api.SonarRuntime;
+import org.sonar.api.internal.SonarRuntimeImpl;
+import org.sonar.api.utils.Version;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AuthAadPluginTest {
-  AuthAadPlugin underTest = new AuthAadPlugin();
+  Plugin.Context context;
 
   @Test
   public void test_extensions() {
-    assertThat(underTest.getExtensions()).hasSize(11);
+    assertThat(this.context.getExtensions()).hasSize(11);
   }
 
+  public AuthAadPluginTest() {
+    SonarRuntime runtime = SonarRuntimeImpl.forSonarQube(Version.create(6, 7), SonarQubeSide.SERVER);
+    this.context = new Plugin.Context(runtime);
+    AuthAadPlugin underTest = new AuthAadPlugin();
+    underTest.define(context);
+  }
 }


### PR DESCRIPTION
Remove deprecation warnings for both the SonarQube API and the Apache Commons package.

Additionally, bump version to 1.1.1-alpha as this can probably be a patch release right now.