### PR TITLE
Java Fix for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 sudo: false
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,16 @@ jdk:
   - oraclejdk8
 
 script:
-  - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar
+  - |
+    if [ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then
+      echo;
+      echo "Running Build with SonarCloud Scanning";
+      mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar $MAVEN_OPTIONS;
+    else
+      echo;
+      echo "Running a normal test suite with no SonarCloud";
+      mvn clean install;
+    fi;
 
 cache:
   directories:


### PR DESCRIPTION
Configure Travis-CI to use latest Ubuntu LTS that supports JDK 8 decently.