### PR TITLE
Partial fix for #79: Changes memberOf to transitiveMemberOf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.almrangers.auth.aad</groupId>
     <artifactId>sonar-auth-aad-plugin</artifactId>
-    <version>1.1</version>
+    <version>1.2-rc.2</version>
     <packaging>sonar-plugin</packaging>
 
     <name>Azure Active Directory (AAD) Authentication Plug-in for SonarQube</name>

--- a/src/main/java/org/almrangers/auth/aad/AadSettings.java
+++ b/src/main/java/org/almrangers/auth/aad/AadSettings.java
@@ -73,7 +73,7 @@ public class AadSettings {
   protected static final String GRAPH_URL_DE = "https://graph.microsoft.de";
   protected static final String GRAPH_URL_CN = "https://microsoftgraph.chinacloudapi.cn";
   protected static final String AUTH_REQUEST_FORMAT = "%s?client_id=%s&response_type=code&redirect_uri=%s&state=%s&scope=openid";
-  protected static final String GROUPS_REQUEST_FORMAT = "/v1.0/%s/users/%s/memberOf";
+  protected static final String GROUPS_REQUEST_FORMAT = "/v1.0/%s/users/%s/transitiveMemberOf";
 
   private final Settings settings;
 

--- a/src/test/java/org/almrangers/auth/aad/AadSettingsTest.java
+++ b/src/test/java/org/almrangers/auth/aad/AadSettingsTest.java
@@ -87,6 +87,12 @@ public class AadSettingsTest {
     assertThat(underTest.authorizationUrl().startsWith("https://login.chinacloudapi.cn"));
     assertThat(underTest.getGraphURL().startsWith("https://microsoftgraph.chinacloudapi.cn"));
   }
+  
+  @Test
+  public void return_graph_membership_url() {
+    settings.setProperty("sonar.auth.aad.directoryLocation", DIRECTORY_LOC_GLOBAL);
+    assertThat(underTest.getGraphMembershipUrl()).isEqualTo("https://graph.microsoft.com/v1.0/%s/users/%s/transitiveMemberOf");
+  }
 
   @Test
   public void is_enabled_always_return_false_when_client_id_is_null() {


### PR DESCRIPTION
`/transitiveMemberOf` will return all the groups from `/memberOf` as well as all the groups that a user is a nested member of

Dependency of #81, this is only fix `a`

> In my opinion #79 are two separate issues:
> a) enhancement request to replace memberOf with transitiveMemberOf
> b) fix pagination regression issue created by this [commit](https://github.com/hkamel/sonar-auth-aad/commit/d8dc93b77ccb8d41904697ba98672dda175d649a#diff-1f4964536f397e8679625954c7139bd6)

This change has been tested (with #81) on an instance of sonar qube.

Note that when signing in on my account previously only 1 api request was being sent, with this change 7 were made. Perhaps an option could exist to select either direct membership or nested membership?