### PR TITLE
Ignore groups without valid display name

### DIFF
--- a/src/main/java/org/almrangers/auth/aad/AadGroup.java
+++ b/src/main/java/org/almrangers/auth/aad/AadGroup.java
@@ -54,5 +54,9 @@ public class AadGroup {
   public void setDisplayName(String displayName) {
     this.displayName = displayName;
   }
-
+  
+  public boolean isValid() {
+    return displayName != null && !displayName.isEmpty();
+  }
+  
 }

--- a/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
+++ b/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
@@ -209,7 +209,9 @@ public class AadIdentityProvider implements OAuth2IdentityProvider {
 	        JSONObject thisUserJSONObject = groups.optJSONObject(i);
 	        group = new AadGroup();
 	        JSONHelper.convertJSONObjectToDirectoryObject(thisUserJSONObject, group);
-	        userGroups.add(group.getDisplayName());
+	        if (group.isValid()) {
+              userGroups.add(group.getDisplayName());
+	        }
 	      }
 	      nextPage = JSONHelper.fetchNextPageLink(response);
       } while (StringUtils.isNotEmpty(nextPage));


### PR DESCRIPTION
Recently AAD logins for some of our users started failing with the following error message in the logs:
`Exception:java.lang.IllegalArgumentException: Group name cannot be empty`

It turns out that Graph API, when queried for group memberships, also returns assigned roles for the user. The AAD application used by SonarQube to log users in did not have admin consent to read roles, and as such, instead of Graph API omitting them from the response, returned an empty object:

```
{
  "@odata.type": "#microsoft.graph.directoryRole",
  "id": "<GUID>",
  "deletedDateTime": null,
  "description": null,
  "displayName": null,
  "roleTemplateId": null
}
```

The authentication plugin then passed the null group to SonarQube and authentication failed with the aforementioned exception. I have added a simple check and now `getUserGroupsMembership` only returns groups with non-empty display names.