### PR TITLE
Enables Client Credentials to call Microsoft Graph

### DIFF
--- a/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
+++ b/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
@@ -207,7 +207,7 @@ public class AadIdentityProvider implements OAuth2IdentityProvider {
 	      int responseCode = connection.getResponseCode();
 	      JSONObject response = HttpClientHelper.processGoodRespStr(responseCode, goodRespStr);
 	      JSONArray groups;
-	      groups = JSONHelper.fetchDirectoryObjectJSONArray(response);
+	      groups = JSONHelper.fetchDirectoryObjectJSONArray(response);      
 	      AadGroup group;
 	      for (int i = 0; i < groups.length(); i++) {
 	        JSONObject thisUserJSONObject = groups.optJSONObject(i);
@@ -224,7 +224,7 @@ public class AadIdentityProvider implements OAuth2IdentityProvider {
     }
     return userGroups;
   }
-
+  
   private String generateUniqueLogin(UserInfo aadUser) {
     return String.format("%s@%s", aadUser.getDisplayableId(), getKey());
   }

--- a/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
+++ b/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
@@ -136,7 +136,11 @@ public class AadIdentityProvider implements OAuth2IdentityProvider {
         .setName(getUserName(result))
         .setEmail(aadUser.getDisplayableId());
       if (settings.enableGroupSync()) {
-        userGroups = getUserGroupsMembership(result.getAccessToken(), result.getUserInfo().getUniqueId());
+    	if (settings.enableClientCredential()) {
+    		Future<AuthenticationResult> clientFuture = authContext.acquireToken(settings.getGraphURL(), clientCredt, null);
+    		result = clientFuture.get();
+    	}
+        userGroups = getUserGroupsMembership(result.getAccessToken(), aadUser.getUniqueId());
         userIdentityBuilder.setGroups(userGroups);
       }
       context.authenticate(userIdentityBuilder.build());

--- a/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
+++ b/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
@@ -136,10 +136,10 @@ public class AadIdentityProvider implements OAuth2IdentityProvider {
         .setName(getUserName(result))
         .setEmail(aadUser.getDisplayableId());
       if (settings.enableGroupSync()) {
-    	if (settings.enableClientCredential()) {
-    		Future<AuthenticationResult> clientFuture = authContext.acquireToken(settings.getGraphURL(), clientCredt, null);
-    		result = clientFuture.get();
-    	}
+        if (settings.enableClientCredential()) {
+          Future<AuthenticationResult> clientFuture = authContext.acquireToken(settings.getGraphURL(), clientCredt, null);
+          result = clientFuture.get();
+        }
         userGroups = getUserGroupsMembership(result.getAccessToken(), aadUser.getUniqueId());
         userIdentityBuilder.setGroups(userGroups);
       }
@@ -207,7 +207,7 @@ public class AadIdentityProvider implements OAuth2IdentityProvider {
 	      int responseCode = connection.getResponseCode();
 	      JSONObject response = HttpClientHelper.processGoodRespStr(responseCode, goodRespStr);
 	      JSONArray groups;
-	      groups = JSONHelper.fetchDirectoryObjectJSONArray(response);      
+	      groups = JSONHelper.fetchDirectoryObjectJSONArray(response);
 	      AadGroup group;
 	      for (int i = 0; i < groups.length(); i++) {
 	        JSONObject thisUserJSONObject = groups.optJSONObject(i);
@@ -224,7 +224,7 @@ public class AadIdentityProvider implements OAuth2IdentityProvider {
     }
     return userGroups;
   }
-  
+
   private String generateUniqueLogin(UserInfo aadUser) {
     return String.format("%s@%s", aadUser.getDisplayableId(), getKey());
   }

--- a/src/main/java/org/almrangers/auth/aad/AadSettings.java
+++ b/src/main/java/org/almrangers/auth/aad/AadSettings.java
@@ -51,6 +51,7 @@ public class AadSettings {
   protected static final String DIRECTORY_LOC_DE = "Azure AD for Germany";
   protected static final String DIRECTORY_LOC_CN = "Azure AD China";
   protected static final String ENABLE_GROUPS_SYNC = "sonar.auth.aad.enableGroupsSync";
+  protected static final String ENABLE_CLIENT_CRED = "sonar.auth.aad.enableClientCredential";
   protected static final String LOGIN_STRATEGY = "sonar.auth.aad.loginStrategy";
   protected static final String LOGIN_STRATEGY_UNIQUE = "Unique";
   protected static final String LOGIN_STRATEGY_PROVIDER_ID = "Same as Azure AD login";
@@ -162,6 +163,15 @@ public class AadSettings {
         .type(BOOLEAN)
         .defaultValue(valueOf(false))
         .index(9)
+        .build(),
+      PropertyDefinition.builder(ENABLE_CLIENT_CRED)
+        .name("Enable Client Credential Flow")
+        .description("Needs a description")
+        .category(CATEGORY)
+        .subCategory(GROUPSYNCSUBCATEGORY)
+        .type(BOOLEAN)
+        .defaultValue(valueOf(false))
+        .index(10)
         .build()
     );
   }
@@ -177,6 +187,10 @@ public class AadSettings {
   public boolean enableGroupSync() {
     return config.getBoolean(ENABLE_GROUPS_SYNC).orElse(Boolean.FALSE);
   }
+  
+  public boolean enableClientCredential() {
+	    return config.getBoolean(ENABLE_CLIENT_CRED).orElse(Boolean.FALSE);
+	  }
 
   public boolean multiTenant() {
     return config.getBoolean(MULTI_TENANT).orElse(Boolean.FALSE);

--- a/src/main/java/org/almrangers/auth/aad/AadSettings.java
+++ b/src/main/java/org/almrangers/auth/aad/AadSettings.java
@@ -189,8 +189,8 @@ public class AadSettings {
   }
 
   public boolean enableClientCredential() {
-	  return config.getBoolean(ENABLE_CLIENT_CRED).orElse(Boolean.FALSE);
-	}
+    return config.getBoolean(ENABLE_CLIENT_CRED).orElse(Boolean.FALSE);
+  }
 
   public boolean multiTenant() {
     return config.getBoolean(MULTI_TENANT).orElse(Boolean.FALSE);

--- a/src/main/java/org/almrangers/auth/aad/AadSettings.java
+++ b/src/main/java/org/almrangers/auth/aad/AadSettings.java
@@ -166,7 +166,8 @@ public class AadSettings {
         .build(),
       PropertyDefinition.builder(ENABLE_CLIENT_CRED)
         .name("Enable Client Credential Flow")
-        .description("Enable client credentials to be used to synchronize groups. This will use the client id and client secret to connect to Microsoft Graph. Should only be used with 'Application' permissions.")
+        .description("Enable client credentials to be used to synchronize groups. This will use the client id and client secret to connect to Microsoft Graph. "
+        		+ "Should only be used with 'Application' permissions. Requires multi-tenant to be 'false'.")
         .category(CATEGORY)
         .subCategory(GROUPSYNCSUBCATEGORY)
         .type(BOOLEAN)
@@ -189,7 +190,7 @@ public class AadSettings {
   }
 
   public boolean enableClientCredential() {
-    return config.getBoolean(ENABLE_CLIENT_CRED).orElse(Boolean.FALSE);
+    return config.getBoolean(ENABLE_CLIENT_CRED).orElse(Boolean.FALSE) && !multiTenant();
   }
 
   public boolean multiTenant() {

--- a/src/main/java/org/almrangers/auth/aad/AadSettings.java
+++ b/src/main/java/org/almrangers/auth/aad/AadSettings.java
@@ -187,10 +187,10 @@ public class AadSettings {
   public boolean enableGroupSync() {
     return config.getBoolean(ENABLE_GROUPS_SYNC).orElse(Boolean.FALSE);
   }
-  
+
   public boolean enableClientCredential() {
-	    return config.getBoolean(ENABLE_CLIENT_CRED).orElse(Boolean.FALSE);
-	  }
+	  return config.getBoolean(ENABLE_CLIENT_CRED).orElse(Boolean.FALSE);
+	}
 
   public boolean multiTenant() {
     return config.getBoolean(MULTI_TENANT).orElse(Boolean.FALSE);

--- a/src/main/java/org/almrangers/auth/aad/AadSettings.java
+++ b/src/main/java/org/almrangers/auth/aad/AadSettings.java
@@ -166,7 +166,7 @@ public class AadSettings {
         .build(),
       PropertyDefinition.builder(ENABLE_CLIENT_CRED)
         .name("Enable Client Credential Flow")
-        .description("Needs a description")
+        .description("Enable client credentials to be used to synchronize groups. This will use the client id and client secret to connect to Microsoft Graph. Should only be used with 'Application' permissions.")
         .category(CATEGORY)
         .subCategory(GROUPSYNCSUBCATEGORY)
         .type(BOOLEAN)

--- a/src/test/java/org/almrangers/auth/aad/AadSettingsTest.java
+++ b/src/test/java/org/almrangers/auth/aad/AadSettingsTest.java
@@ -139,11 +139,23 @@ public class AadSettingsTest {
     settings.setProperty("sonar.auth.aad.enableGroupsSync", false);
     assertThat(underTest.enableGroupSync()).isFalse();
   }
-  
+
   @Test
-  public void return_client_cred() {
+  public void return_client_cred_when_multiTenant_is_false() {
+    settings.setProperty("sonar.auth.aad.multiTenant", "false");
+
     settings.setProperty("sonar.auth.aad.enableClientCredential", true);
     assertThat(underTest.enableClientCredential()).isTrue();
+    settings.setProperty("sonar.auth.aad.enableClientCredential", false);
+    assertThat(underTest.enableClientCredential()).isFalse();
+  }
+
+  @Test
+  public void client_cred_always_return_false_when_multiTenant_is_true() {
+    settings.setProperty("sonar.auth.aad.multiTenant", "true");
+
+    settings.setProperty("sonar.auth.aad.enableClientCredential", true);
+    assertThat(underTest.enableClientCredential()).isFalse();
     settings.setProperty("sonar.auth.aad.enableClientCredential", false);
     assertThat(underTest.enableClientCredential()).isFalse();
   }

--- a/src/test/java/org/almrangers/auth/aad/AadSettingsTest.java
+++ b/src/test/java/org/almrangers/auth/aad/AadSettingsTest.java
@@ -139,6 +139,14 @@ public class AadSettingsTest {
     settings.setProperty("sonar.auth.aad.enableGroupsSync", false);
     assertThat(underTest.enableGroupSync()).isFalse();
   }
+  
+  @Test
+  public void return_client_cred() {
+    settings.setProperty("sonar.auth.aad.enableClientCredential", true);
+    assertThat(underTest.enableClientCredential()).isTrue();
+    settings.setProperty("sonar.auth.aad.enableClientCredential", false);
+    assertThat(underTest.enableClientCredential()).isFalse();
+  }
 
   @Test
   public void return_authority_url() {
@@ -159,6 +167,6 @@ public class AadSettingsTest {
 
   @Test
   public void definitions() {
-    assertThat(AadSettings.definitions()).hasSize(9);
+    assertThat(AadSettings.definitions()).hasSize(10);
   }
 }

--- a/src/test/java/org/almrangers/auth/aad/AuthAadPluginTest.java
+++ b/src/test/java/org/almrangers/auth/aad/AuthAadPluginTest.java
@@ -40,7 +40,7 @@ public class AuthAadPluginTest {
 
   @Test
   public void test_extensions() {
-    assertThat(this.context.getExtensions()).hasSize(11);
+    assertThat(this.context.getExtensions()).hasSize(12);
   }
 
   public AuthAadPluginTest() {


### PR DESCRIPTION
There is a setting in Microsoft Azure Active Directory that prevents guest users from retrieving graph data. Including the group display name, which is used in group synchronization.

https://docs.microsoft.com/en-us/azure/active-directory/users-groups-roles/users-restrict-guest-permissions

With this setting set to `restricted`, the graph api returns empty group objects and therefore doesn't sync groups.

This PR adds a new option to allow the use of client credentials. So instead of granting an application `Directory.AccessAsUser.All (Delegated)` you need to give it `Directory.Read.All (Application)`.
`Directory.Read.All` is the least most privileged permission required as per https://docs.microsoft.com/en-us/graph/api/user-list-transitivememberof.

As the application permissions are granted for the tenant, this setting cannot be used with multi tenant enabled.

The initial [`authContext.acquireTokenByAuthorizationCode`](https://github.com/hkamel/sonar-auth-aad/blob/372facaae1386f37d9a6d69ed64adb51be8327e2/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java#L128-L129) is still required to retrieve the user information from the id token claims, as `authContext.acquireToken` wont retrieve this data. 