### PR TITLE
Migrate from javax to jakarta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.almrangers.auth.aad</groupId>
     <artifactId>sonar-auth-aad-plugin</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <packaging>sonar-plugin</packaging>
 
     <name>Azure Active Directory (AAD) Authentication Plug-in for SonarQube</name>
@@ -81,9 +81,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.sonarsource.sonarqube</groupId>
+            <groupId>org.sonarsource.api.plugin</groupId>
             <artifactId>sonar-plugin-api</artifactId>
-            <version>8.9.0.43852</version>
+            <version>11.0.0.2664</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
+++ b/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
@@ -29,7 +29,6 @@ package org.almrangers.auth.aad;
 
 import java.net.*;
 import java.util.concurrent.ExecutorService;
-import javax.servlet.http.HttpServletRequest;
 
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.oauth2.sdk.*;
@@ -45,6 +44,7 @@ import org.sonar.api.server.ServerSide;
 import org.sonar.api.server.authentication.Display;
 import org.sonar.api.server.authentication.OAuth2IdentityProvider;
 import org.sonar.api.server.authentication.UnauthorizedException;
+import org.sonar.api.server.http.HttpRequest;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
@@ -130,7 +130,7 @@ public class AadIdentityProvider implements OAuth2IdentityProvider {
   void onCallback(CallbackContext context) throws UnauthorizedException {
     context.verifyCsrfState();
 
-    HttpServletRequest request = context.getRequest();
+    HttpRequest request = context.getHttpRequest();
     AuthorizationCode code = new AuthorizationCode(request.getParameter("code"));
     ExecutorService service = null;
 

--- a/src/test/java/org/almrangers/auth/aad/AadIdentityProviderTest.java
+++ b/src/test/java/org/almrangers/auth/aad/AadIdentityProviderTest.java
@@ -36,6 +36,7 @@ import org.mockito.ArgumentCaptor;
 import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.server.authentication.OAuth2IdentityProvider;
 import org.sonar.api.server.authentication.UnauthorizedException;
+import org.sonar.api.server.http.HttpRequest;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
@@ -60,10 +61,10 @@ public class AadIdentityProviderTest {
   public void fail_login_on_bad_auth_code() {
     setSettings(true);
     OAuth2IdentityProvider.CallbackContext context = mock(OAuth2IdentityProvider.CallbackContext.class);
-    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpRequest request = mock(HttpRequest.class);
 
     when(request.getParameter("code")).thenReturn("9Q4mHqIAmAHORqpwwUaAxnGh");
-    when(context.getRequest()).thenReturn(request);
+    when(context.getHttpRequest()).thenReturn(request);
 
     assertThrows(UnauthorizedException.class,
         () -> underTest.onCallback(context)


### PR DESCRIPTION
To be compatible with SonarQube 25.1 a migration was necessary. I updated the code to work with 25.1 again.